### PR TITLE
add touch control areas for timer functionality

### DIFF
--- a/MMM-Pomodoro.css
+++ b/MMM-Pomodoro.css
@@ -45,7 +45,7 @@
 .black_overlay {
   position: fixed;
   z-index: 2;
-  background-color: rgba(0, 0, 0, 0.93);
+  /* background-color: rgba(0, 0, 0, 0.93); this is weird! it makes it nearly invisible!*/
   width: 100%;
   height: 100%;
 }

--- a/MMM-Pomodoro.css
+++ b/MMM-Pomodoro.css
@@ -19,7 +19,7 @@
   border-style: solid;
   border-color: #666;
 }
-
+/* this class defines the position of the notification */
 .ns-alert {
   border-style: solid;
   border-color: #fff;
@@ -35,11 +35,14 @@
   left: 0;
   margin-right: auto;
   margin-left: auto;
-  top: 40%;
   width: 30%;
   height: auto;
   word-wrap: break-word;
   border-radius: 20px;
+}
+
+.ns-alert:first-child {
+  top: 40%;
 }
 
 .black_overlay {

--- a/MMM-Pomodoro.js
+++ b/MMM-Pomodoro.js
@@ -244,8 +244,12 @@ Module.register("MMM-Pomodoro", {
 
 	removeOverlay: function() {
 		const overlay = document.getElementById("overlay");
-		overlay.parentNode.removeChild(overlay);
-		document.body.removeChild(this.ntf);
+		if (overlay && overlay.parentNode) {
+			overlay.parentNode.removeChild(overlay);
+		}
+		if (this.ntf && document.body.contains(this.ntf)) {
+			document.body.removeChild(this.ntf);
+		}
 		this.isVisible = false;
 		this.firstMessage = true;
 		this.nextType = null;

--- a/README.md
+++ b/README.md
@@ -51,4 +51,11 @@ The following options can be configured in the config.js file:
 | **Option** | **Description**|
 |------------|----------------|
 | ``` animation ``` | Controls if the timer/stopwatch should be animated. **Default:** *true* |
+| ```longRelaxTime```     | Time for a long relaxation break (default: 30*60 seconds) |
+| ```shortRelaxTime```    | Time for a short relaxation break (default: 5*60 seconds) |
+| ```pomodoroTime```      | Duration of a pomodoro session (default: 25*60 seconds) |
+| ```startArea```         | Defines the rectangular area for initiating the timer. Format: `{ x: 0, y: 0, width: 240, height: 240 }`. Touch or click within this area will start the timer. |
+| ```togglePauseArea```   | Defines the rectangular area for toggling pause. Format: `{ x: 240, y: 0, width: 240, height: 240 }`. Touch or click within this area pauses or unpauses the timer/stopwatch. |
+| ```interruptArea```     | Defines the rectangular area for interruption. Format: `{ x: 480, y: 0, width: 240, height: 240 }`. Touch or click within this area will interrupt the current session. |
 
+Above options allow for intuitive touch or click control on devices with a touchscreen. The defined area coordinates determine which section of the interface responds to the respective control actions. These areas are *invisible*!

--- a/README.md
+++ b/README.md
@@ -59,3 +59,32 @@ The following options can be configured in the config.js file:
 | ```interruptArea```     | Defines the rectangular area for interruption. Format: `{ x: 480, y: 0, width: 240, height: 240 }`. Touch or click within this area will interrupt the current session. |
 
 Above options allow for intuitive touch or click control on devices with a touchscreen. The defined area coordinates determine which section of the interface responds to the respective control actions. These areas are *invisible*!
+
+# Styling
+The main styling is done with `ns-alert` - which being a German is a perculiar name for a css class... Below the default:
+```css
+.ns-alert {
+  border-style: solid;
+  border-color: #fff;
+  padding: 17px;
+  line-height: 1.4;
+  margin-bottom: 10px;
+  z-index: 3;
+  color: white;
+  font-size: 100%;
+  position: unset;
+  text-align: center;
+  right: 0;
+  left: 0;
+  margin-right: auto;
+  margin-left: auto;
+  width: 30%;
+  height: auto;
+  word-wrap: break-word;
+  border-radius: 20px;
+}
+
+.ns-alert:first-child {  // this makes sure that the buttons after the timer has run out are visible
+  top: 40%;
+}
+```


### PR DESCRIPTION
Added descriptions for configuration options such as pomodoroTime, startArea, togglePauseArea, and interruptArea.
Included a section on touch or click control areas for devices with a touchscreen.
Provided default CSS styling for the ns-alert class, which defines the position and appearance of notifications.
Ensured that the ns-alert:first-child CSS rule is documented to explain its purpose in making buttons visible after the timer has run out.